### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,97 +26,6 @@ Installing this theme adds 28 different themes:
 - `ios-dark-mode-dark-blue`
 - `...` and versions with the `-alternative` suffix
 
----
-
-## **🖼️ Backgrounds: Remote vs Local**
-
-As of version **3.0.0**, we have introduced an alternative to Base64-encoded background images to boost performance.
-
-By default, iOS Themes now use **remote background images** hosted on GitHub for faster caching and loading times. However, for users that prefer to host images locally on their Home Assistant setup (or in environments with poor internet connectivity), `-alternative` versions of the themes are available, which use locally hosted background images.
-
-### **Remote Backgrounds (Default)**
-
-- The default themes use background images stored in our GitHub repository.
-- To switch to the default themes, no configuration beyond the installation steps is necessary.
-
-### **Local Backgrounds (Alternative Versions)**
-
-For the alternative themes, you will need to **download the images and store them locally** in your Home Assistant's `/config/www/ios-themes` directory. Home Assistant automatically serves files from the `www` folder under `/local/`.
-
----
-
-<details>
-<summary>📥 How to Download Backgrounds for Local Use (Alternative Themes)</summary>
-
-### **Step-by-Step Local Background Setup**:
-
-To use locally hosted background images, follow the instructions below.
-
-1. **Create the necessary directory**:
-   Open a terminal (or SSH into your Home Assistant setup) and run the following command to ensure the correct folder structure is in place:
-   ```bash
-   mkdir -p /config/www/ios-themes
-   ```
-
-2. **Download the background images**:
-   Download the required background images using `wget` commands. This will store them in the `/config/www/ios-themes` folder.
-   
-   For example:
-   ```bash
-   # Dark Blue background
-   wget -O /config/www/ios-themes/homekit-bg-dark-blue.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-dark-blue.jpg
-   
-   # Light Blue background
-   wget -O /config/www/ios-themes/homekit-bg-dark-blue.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-light-blue.jpg
-   
-   # Add more backgrounds as needed for other themes
-   ```
-
-   Repeat the command for all the backgrounds you need (ensure to replace `dark-blue.jpg` with the appropriate background name from the themes you're using).
-
-3. **Switch to the alternative theme**:
-   In your Home Assistant profile settings, select the **alternative version** of the theme you want to use.  
-   Example: `ios-dark-mode-dark-blue-alternative`
-
-   **Important:** For images hosted locally, the background paths in the theme are referenced as `/local/ios-themes/...`.
-
----
-
-### **Command Summary for Downloading Backgrounds**:
-
-Here are commands to download all available backgrounds:
-
-```bash
-# Dark Blue
-wget -O /config/www/ios-themes/homekit-bg-dark-blue.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-dark-blue.jpg
-
-# Light Blue
-wget -O /config/www/ios-themes/homekit-bg-light-blue.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-light-blue.jpg
-
-# Dark Green
-wget -O /config/www/ios-themes/homekit-bg-dark-green.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-dark-green.jpg
-
-# Light Green
-wget -O /config/www/ios-themes/homekit-bg-light-green.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-light-green.jpg
-
-# Orange
-wget -O /config/www/ios-themes/homekit-bg-orange.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-orange.jpg
-
-# Blue Red
-wget -O /config/www/ios-themes/homekit-bg-blue-red.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-blue-red.jpg
-
-# Red
-wget -O /config/www/ios-themes/homekit-bg-red.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-red.jpg
-```
-
----
-
-After placing the images in the `/config/www/ios-themes/` directory, reload your Home Assistant theme settings (or restart Home Assistant) and enjoy using the responsive, locally hosted backgrounds!
-
-</details>
-
----
-
 ## Screenshots
 
 Screenshots of [my](https://github.com/basnijholt) Home-Assistant instance, [see the config files here :octocat:](https://github.com/basnijholt/home-assistant-config/).
@@ -145,14 +54,14 @@ Low quality `gif`, click [here](https://github.com/basnijholt/lovelace-ios-theme
 
 ## Installation
 
-1. Installation of the themes with HACS.
+1. Install the theme via HACS.
 
-* (If you do not have it yet) Install [HACS](https://hacs.xyz/docs/installation/manual).
-* Go to the HACS Community Store.
-* Click on the `THEMES` tab.
-* Search and install the `iOS Themes`.
+* If you do not have HACS yet, [download and set it up](https://www.hacs.xyz/docs/use/download/download/) first — a GitHub account is required.
+* In Home Assistant, open **HACS** from the sidebar.
+* Search for `iOS Themes` and select it.
+* In the bottom-right corner, select **Download**.
 
-2. Add the following code to your `configuration.yaml` file (reboot required).
+2. Add the following to your `configuration.yaml` (reboot required).
 
 ```yaml
 frontend:
@@ -161,7 +70,10 @@ frontend:
   ... # your configuration.
 ```
 
-3. Add the following line to your `lovelace-ui.yaml` or use the RAW editor:
+3. Set the background on your dashboard.
+
+Open your dashboard, select **Edit dashboard** (pencil icon) → **⋮ Open dashboard menu** → **Raw configuration editor**, and add this at the top level:
+
 ```yaml
 background: var(--background-image)
 ```
@@ -169,9 +81,10 @@ background: var(--background-image)
 So the end result will be something like [this example](https://github.com/basnijholt/home-assistant-config/blob/master/lovelace-ui.yaml).
 
 ## Automations to easily switch
-**WARNING: if you want to switch themes using automations, you need to go to your profile and select "Backend-selected" for Theme!**
 
-It is recommended to use [these automations (`basnijholt/home-assistant-config/automations/frontend.yaml`)](https://github.com/basnijholt/home-assistant-config/blob/master/automations/frontend.yaml) in combination with these:
+**Note:** To switch themes via automations or the UI helpers below, go to your profile (**Settings** → **[your name]**) and set **Theme** to **Backend-selected**.
+
+It is recommended to use [these automations (`basnijholt/home-assistant-config/automations/frontend.yaml`)](https://github.com/basnijholt/home-assistant-config/blob/master/automations/frontend.yaml) in combination with these helpers:
 ```yaml
 input_select:
   theme:
@@ -192,10 +105,32 @@ input_boolean:
   theme_alternative:
     name: Theme alternative (disable active state color)
 ```
-Then add `input_select.theme`, `input_boolean.theme_alternative`, and `input_boolean.dark_mode` to your Lovelace UI.
+
+You can define these helpers in `configuration.yaml` as shown above, or create them via **Settings** → **Devices & Services** → **Helpers**. Then add `input_select.theme`, `input_boolean.theme_alternative`, and `input_boolean.dark_mode` to your dashboard.
 
 
 ## How does the code work
 
 All the **28(!)** themes in [`themes/`](themes/) are **automatically generated** using [`create-themes.py`](create-themes.py) and the information in [`settings-light-dark.yaml`](settings-light-dark.yaml) is passed into [`template.jinja2`](template.jinja2).
 The resulting file is [`themes/ios-themes.yaml`](themes/ios-themes.yaml) which contains all variants (different backgrounds and dark/light mode).
+
+## HA 2025.5+ compatibility
+
+This theme has been modernized to remove deprecated variables and add support
+for UI components introduced in Home Assistant 2025.5.
+
+**Removed** (Polymer/`paper-*` components were removed in HA 2025.5):
+- `paper-slider-*` — sliders now follow `--primary-color` / `--accent-color` automatically
+- `paper-toggle-button-*` — switches use `switch-checked-*` variables
+- `paper-listbox-background-color`
+- `paper-card-background-color`
+- `paper-item-icon-color` / `paper-item-icon-active-color`
+- Vaadin `--vaadin-text-field-*` input variables
+
+**Updated:**
+- `paper-dialog-background-color` → `dialog-background-color`
+
+**Added** (view tab styling for `ha-tabs` / `sl-tab` in HA 2025.5+):
+- `app-header-selection-bar-color` — active view tab indicator bar colour
+- `sl-color-primary-600` — active view tab text/icon colour
+- `sl-color-neutral-600` — inactive view tab text/icon colour


### PR DESCRIPTION
Installation section (HACS 2.0):

Replaced the old "Go to the HACS Community Store → click THEMES tab" flow with the current HACS 2.0 UI: open HACS from the sidebar, search, hit Download Linked directly to the official HACS download docs rather than the old hacs.xyz/docs/installation/manual page Noted that a GitHub account is required (a HACS 2.0 requirement that wasn't mentioned before) Replaced "add to lovelace-ui.yaml or use the RAW editor" with the current HA UI path: Edit dashboard → ⋮ → Raw configuration editor, since lovelace-ui.yaml is a legacy concept being phased out (global mode: yaml is deprecated as of HA 2026.2, removed in 2026.8)

Automations section:

Softened the all-caps WARNING to a plain **Note:** — still clear, less alarming Updated the profile navigation path to Settings → [your name] to match current HA UI Added the UI-based alternative for creating helpers (Settings → Devices & Services → Helpers) since most users won't be hand-editing YAML for this Changed "Lovelace UI" to "dashboard" throughout, matching current HA terminology